### PR TITLE
FixPathDrawingBeta4

### DIFF
--- a/Turtle.playground/Sources/Secret Turtle Stuff/Turtle.swift
+++ b/Turtle.playground/Sources/Secret Turtle Stuff/Turtle.swift
@@ -62,15 +62,16 @@ public struct Turtle {
     
     // MARK: - Colors
     
-    func penColor(penColor: PenColor) {
+    mutating func penColor(penColor: PenColor) {
+        let path =  Path(penColor: penColor, isPenDown: currentPath.isPenDown, startingPoint:currentPath.currentPoint , uniqueID: currentPath.uniqueID + 1)
+        view.addPath(path)
+        currentPath = path
         if turtleType != .Plain {
-            let path =  Path(penColor: penColor, isPenDown: currentPath.isPenDown, startingPoint:currentPath.currentPoint , uniqueID: currentPath.uniqueID + 1)
-            view.addPath(path)
             turtle = Turtle(currentPath: path, view: view, avatar: avatar.penColor(penColor), turtleType: turtleType)
         }
     }
     
-    func nextColor() {
+    mutating func nextColor() {
         penColor(currentPath.penColor.next())
     }
     

--- a/Turtle.playground/Sources/Secret Turtle Stuff/Turtle.swift
+++ b/Turtle.playground/Sources/Secret Turtle Stuff/Turtle.swift
@@ -83,6 +83,7 @@ public struct Turtle {
 
 extension Turtle: CustomPlaygroundQuickLookable {
     public func customPlaygroundQuickLook() -> PlaygroundQuickLook {
+        view.setNeedsDisplay()
         return PlaygroundQuickLook(reflecting: view)
     }
 

--- a/Turtle.playground/Sources/Secret Turtle Stuff/TurtleView.swift
+++ b/Turtle.playground/Sources/Secret Turtle Stuff/TurtleView.swift
@@ -13,7 +13,7 @@ public class TurtleView: UIView {
         self.backgroundColor =  backgroundColor
         addSubview(avatarView)
     }
-    required public init(coder aDecoder: NSCoder) {
+    required public init?(coder aDecoder: NSCoder) {
         super.init(coder:aDecoder)
     }
     

--- a/Turtle.playground/Sources/What a Turtle Understands/TurtleHeading.swift
+++ b/Turtle.playground/Sources/What a Turtle Understands/TurtleHeading.swift
@@ -15,7 +15,7 @@ public func right() {
 
 // MARK: - left -
 
-public func left(degrees: Double = 90) {
+public func left(degrees: Double) {
     turtle.increaseHeadingBy(-degrees)
 }
 


### PR DESCRIPTION
Colour trails working again. Needed setNeedsDisplay in customPlaygroundQuicklook and also to mutate the current path to set colours for plain turtles.

This branch includes the commits in the beta4 Pull Request I sent yesterday.
